### PR TITLE
Fix beatmap images get shrinked on beatmaps listing

### DIFF
--- a/src/sass/_custom.scss
+++ b/src/sass/_custom.scss
@@ -87,6 +87,7 @@ footer {
     min-height: 100px;
     position: relative;
     overflow: hidden;
+    object-fit: cover;
 }
 
 .card h4 {


### PR DESCRIPTION
Before:
![image](https://github.com/pishifat/mappersguild2/assets/20987315/9b84ddfc-6e14-4a61-af71-92710ef432b0)
After:
![image](https://github.com/pishifat/mappersguild2/assets/20987315/d1d712cb-e68b-43d4-a72e-89952645a2fb)
