### PR TITLE
Interop write route for mentorship cycles (CMP end-of-cycle sync)

### DIFF
--- a/api/archives/migration6 - mentorship records.js
+++ b/api/archives/migration6 - mentorship records.js
@@ -1,0 +1,53 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const config = require('../../config.json');
+const Mongoose = require('mongoose');
+
+async function run() {
+    await Mongoose.connect(config.connection);
+    console.log('ok');
+
+    const db = Mongoose.connection.db;
+    const users = await db.collection('users').find({ 'mentorships.0': { $exists: true } }).toArray();
+
+    console.log(`found ${users.length} users with embedded mentorships`);
+
+    const records = [];
+
+    for (const user of users) {
+        for (const mentorship of user.mentorships) {
+            records.push({
+                user: user._id,
+                cycle: mentorship.cycle,
+                mode: mentorship.mode,
+                group: mentorship.group,
+                mentor: mentorship.mentor,
+                phases: mentorship.phases,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+            });
+        }
+    }
+
+    if (records.length) {
+        const result = await db.collection('mentorshiprecords').insertMany(records);
+        console.log(`inserted ${result.insertedCount} mentorship records`);
+    } else {
+        console.log('nothing to insert');
+    }
+
+    const unsetResult = await db.collection('users').updateMany(
+        { mentorships: { $exists: true } },
+        { $unset: { mentorships: '' } }
+    );
+    console.log(`unset embedded mentorships on ${unsetResult.modifiedCount} users`);
+
+    const publicResult = await db.collection('mentorshipcycles').updateMany(
+        {},
+        { $set: { isPublic: true } }
+    );
+    console.log(`set isPublic on ${publicResult.modifiedCount} cycles`);
+
+    process.exit();
+}
+
+run().catch(err => { console.error(err); process.exit(1); });

--- a/api/models/mentorshipCycle.ts
+++ b/api/models/mentorshipCycle.ts
@@ -10,10 +10,39 @@ const mentorshipCycleSchema = new Schema<MentorshipCycle>({
     isPublic: { type: Boolean, default: false },
 }, { timestamps: true, toJSON: { virtuals: true }, toObject: { virtuals: true } });
 
-mentorshipCycleSchema.virtual('participants', {
-    ref: 'User',
+mentorshipCycleSchema.virtual('records', {
+    ref: 'MentorshipRecord',
     localField: '_id',
-    foreignField: 'mentorships.cycle',
+    foreignField: 'cycle',
+});
+
+// distinct participating users for this cycle
+mentorshipCycleSchema.virtual('participants').get(function(this: any) {
+    if (!this.records) return [];
+
+    const byUser = new Map<string, any>();
+
+    for (const record of this.records) {
+        const user = record.user;
+
+        if (!user) continue;
+
+        const key = user.id;
+
+        if (!byUser.has(key)) {
+            byUser.set(key, {
+                _id: user._id,
+                id: user.id,
+                username: user.username,
+                osuId: user.osuId,
+                mentorships: [],
+            });
+        }
+
+        byUser.get(key).mentorships.push(record);
+    }
+
+    return Array.from(byUser.values());
 });
 
 const MentorshipCycleModel = mongoose.model<MentorshipCycle>('MentorshipCycle', mentorshipCycleSchema);

--- a/api/models/mentorshipRecord.ts
+++ b/api/models/mentorshipRecord.ts
@@ -1,0 +1,27 @@
+import mongoose, { Schema } from 'mongoose';
+import { MentorshipRecord } from '../../interfaces/mentorshipRecord';
+
+const mentorshipModes = [
+    'osu', 'taiko', 'catch', 'mania',
+    'osuModding', 'taikoModding', 'catchModding', 'maniaModding',
+    'osuGraduation', 'taikoGraduation', 'catchGraduation', 'maniaGraduation',
+    'storyboard',
+];
+
+const mentorshipRecordSchema = new Schema({
+    user: { type: 'ObjectId', ref: 'User', required: true },
+    cycle: { type: 'ObjectId', ref: 'MentorshipCycle', required: true },
+    mode: { type: String, enum: mentorshipModes, required: true }, // graduation = mentoring someone on how to mentor. stupid name
+    group: { type: String, enum: ['mentor', 'mentee', 'extraMentor'], required: true },
+    mentor: { type: 'ObjectId', ref: 'User' },
+    phases: [{ type: Number, default: [1, 2, 3] }],
+}, { timestamps: true, toJSON: { virtuals: true }, toObject: { virtuals: true } });
+
+// query performance only
+mentorshipRecordSchema.index({ user: 1, cycle: 1, mode: 1 });
+mentorshipRecordSchema.index({ cycle: 1 });
+mentorshipRecordSchema.index({ mentor: 1 });
+
+const MentorshipRecordModel = mongoose.model<MentorshipRecord>('MentorshipRecord', mentorshipRecordSchema);
+
+export { MentorshipRecordModel };

--- a/api/models/user.ts
+++ b/api/models/user.ts
@@ -11,14 +11,6 @@ const UserSchema = new Schema({
     discordId: { type: String },
     isMentorshipAdmin: { type: Boolean },
     isTeamContestAdmin: { type: Boolean },
-    mentorships: [{
-        _id: false,
-        cycle: { type: 'ObjectId', ref: 'MentorshipCycle', required: true },
-        mode: { type: String, enum: ['osu', 'taiko', 'catch', 'mania', 'osuModding', 'taikoModding', 'catchModding', 'maniaModding', 'osuGraduation', 'taikoGraduation', 'catchGraduation', 'maniaGraduation', 'storyboard'], required: true }, // graduation = mentoring someone on how to mentor. stupid name
-        group: { type: String, enum: ['mentor', 'mentee', 'extraMentor'], required: true },
-        mentor: { type: 'ObjectId', ref: 'User' },
-        phases: [{ type: Number, default: [1, 2, 3] }],
-    }],
     rank: { type: Number, default: 0 },
     easyPoints: { type: Number, default: 0 },
     normalPoints: { type: Number, default: 0 },
@@ -109,10 +101,36 @@ UserSchema.virtual('mainMode').get(function(this: User) {
     return modes[0].name;
 });
 
-UserSchema.virtual('mentees', {
-    ref: 'User',
+UserSchema.virtual('mentorships', {
+    ref: 'MentorshipRecord',
     localField: '_id',
-    foreignField: 'mentorships.mentor',
+    foreignField: 'user',
+});
+
+// where user is mentor
+UserSchema.virtual('menteeRecords', {
+    ref: 'MentorshipRecord',
+    localField: '_id',
+    foreignField: 'mentor',
+});
+
+// distinct mentees
+UserSchema.virtual('mentees').get(function(this: any) {
+    if (!this.menteeRecords) return [];
+
+    const seen = new Set<string>();
+    const result: any[] = [];
+
+    for (const record of this.menteeRecords) {
+        const menteeUser = record.user;
+
+        if (menteeUser && !seen.has(menteeUser.id)) {
+            seen.add(menteeUser.id);
+            result.push(menteeUser);
+        }
+    }
+
+    return result;
 });
 
 interface QueryHelpers {

--- a/api/routes/interOp.ts
+++ b/api/routes/interOp.ts
@@ -4,6 +4,9 @@ import { UserModel } from '../models/user';
 import { ContestModel } from '../models/contest/contest';
 import { ContestMode, ContestStatus } from '../../interfaces/contest/contest';
 import { calculateContestScores } from './contests/listing';
+import { UserGroup } from '../../interfaces/user';
+import { MentorshipCycleModel } from '../models/mentorshipCycle';
+import { getUserInfoFromId, isOsuResponseError, getClientCredentialsGrant } from '../helpers/osuApi';
 
 const interOpRouter = express.Router();
 
@@ -122,6 +125,119 @@ interOpRouter.get('/allMentorships', async (req, res) => {
     } catch (error) {
         res.status(500).json({ error: 'Internal server error' });
     }
+});
+
+/* POST a whole mentorship cycle's participants (bulk, append-with-dedupe).
+   Used by the CMP site (osucmp.com) once at the end of each cycle, so MG's
+   mentorship pages stay accurate without manual re-entry. Modeled on
+   addMentor/addMentee in routes/mentorship.ts. */
+interOpRouter.post('/mentorshipCycle', async (req, res) => {
+    const { number, name, url, startDate, endDate, participants, dryRun } = req.body;
+
+    if (!number || !Array.isArray(participants)) {
+        return res.status(400).json({ error: 'number and participants are required' });
+    }
+
+    let cycle = await MentorshipCycleModel.findOne({ number });
+
+    if (!cycle && !dryRun) {
+        cycle = new MentorshipCycleModel();
+        cycle.number = number;
+        cycle.name = name || `Cycle ${number}`;
+        if (url) cycle.url = url;
+        if (startDate) cycle.startDate = new Date(startDate);
+        if (endDate) cycle.endDate = new Date(endDate);
+        await cycle.save();
+    }
+
+    const response = await getClientCredentialsGrant();
+
+    if (isOsuResponseError(response)) {
+        return res.status(500).json({ error: 'osu! auth failed' });
+    }
+
+    const token = response.access_token;
+    let created = 0;
+    let skipped = 0;
+    const errors: string[] = [];
+
+    const findOrCreateUser = async (osuId: number) => {
+        let user = await UserModel.findOne({ osuId });
+
+        if (!user) {
+            const userInfo = await getUserInfoFromId(token, osuId.toString());
+
+            if (isOsuResponseError(userInfo)) {
+                return null;
+            }
+
+            user = new UserModel();
+            user.osuId = userInfo.id;
+            user.username = userInfo.username;
+            user.group = UserGroup.User;
+
+            if (!dryRun) {
+                await user.save();
+            }
+        }
+
+        return user;
+    };
+
+    for (const p of participants) {
+        if (!p.osuId || !p.mode || !['mentor', 'extraMentor', 'mentee'].includes(p.group)) {
+            errors.push(`invalid entry: ${JSON.stringify(p).slice(0, 100)}`);
+            continue;
+        }
+
+        const user = await findOrCreateUser(p.osuId);
+
+        if (!user) {
+            errors.push(`osuId ${p.osuId}: not found on osu!`);
+            continue;
+        }
+
+        const exists = cycle && user.mentorships.some(m =>
+            m.cycle.toString() == cycle.id && m.mode == p.mode && m.group == p.group);
+
+        if (exists) {
+            skipped++;
+            continue;
+        }
+
+        let mentorRef: any;
+
+        if (p.group == 'mentee' || p.group == 'extraMentor') {
+            const mentor = await findOrCreateUser(p.mentorOsuId);
+
+            if (!mentor) {
+                errors.push(`osuId ${p.osuId}: mentor ${p.mentorOsuId} not found on osu!`);
+                continue;
+            }
+
+            mentorRef = mentor._id;
+        }
+
+        if (!dryRun && cycle) {
+            const newMentorship: any = {
+                cycle: cycle._id,
+                mode: p.mode,
+                group: p.group,
+                phases: p.group == 'mentee' ? (p.phases || [1, 2, 3]) : [1, 2, 3],
+            };
+
+            if (mentorRef) {
+                newMentorship.mentor = mentorRef;
+            }
+
+            user.mentorships.push(newMentorship);
+            await user.save();
+        }
+
+        created++;
+    }
+
+    res.json({ created, skipped, errors });
 });
 
 export default interOpRouter;

--- a/api/routes/interOp.ts
+++ b/api/routes/interOp.ts
@@ -223,7 +223,7 @@ interOpRouter.post('/mentorshipCycle', async (req, res) => {
                 cycle: cycle._id,
                 mode: p.mode,
                 group: p.group,
-                phases: p.group == 'mentee' ? (p.phases || [1, 2, 3]) : [1, 2, 3],
+                phases: p.phases || [1, 2, 3],
             };
 
             if (mentorRef) {

--- a/api/routes/interOp.ts
+++ b/api/routes/interOp.ts
@@ -4,9 +4,8 @@ import { UserModel } from '../models/user';
 import { ContestModel } from '../models/contest/contest';
 import { ContestMode, ContestStatus } from '../../interfaces/contest/contest';
 import { calculateContestScores } from './contests/listing';
-import { UserGroup } from '../../interfaces/user';
 import { MentorshipCycleModel } from '../models/mentorshipCycle';
-import { getUserInfoFromId, isOsuResponseError, getClientCredentialsGrant } from '../helpers/osuApi';
+import { MentorshipRecordModel } from '../models/mentorshipRecord';
 
 const interOpRouter = express.Router();
 
@@ -25,8 +24,18 @@ interOpRouter.use((req, res, next) => {
         return res.status(401).json({ error: 'Invalid credentials' });
     }
 
+    res.locals.interOpConfig = userConfig;
+
     return next();
 });
+
+function canWriteMentorships(req, res, next): void {
+    if (res.locals.interOpConfig?.canWriteMentorships) {
+        return next();
+    }
+
+    return res.status(403).json({ error: 'This credential is not permitted to write mentorship data' });
+}
 
 /* GET user mentorships by osuId or username */
 interOpRouter.get('/userMentorships/:id', async (req, res) => {
@@ -40,13 +49,13 @@ interOpRouter.get('/userMentorships/:id', async (req, res) => {
             // Search by username
             user = await UserModel.findOne()
                 .byUsername(identifier)
-                .select('osuId username mentorships')
-                .populate('mentorships.cycle', 'name');
+                .select('osuId username')
+                .populate({ path: 'mentorships', populate: { path: 'cycle', select: 'name' } });
         } else {
             // Search by osuId
             user = await UserModel.findOne({ osuId })
-                .select('osuId username mentorships')
-                .populate('mentorships.cycle', 'name');
+                .select('osuId username')
+                .populate({ path: 'mentorships', populate: { path: 'cycle', select: 'name' } });
         }
 
         if (!user) {
@@ -54,7 +63,7 @@ interOpRouter.get('/userMentorships/:id', async (req, res) => {
         }
 
         res.json(user);
-    } catch (error) {
+    } catch {
         res.status(500).json({ error: 'Internal server error' });
     }
 });
@@ -117,30 +126,71 @@ interOpRouter.get('/contestResults/:mode', async (req, res) => {
 /* GET all mentorships */
 interOpRouter.get('/allMentorships', async (req, res) => {
     try {
-        const users = await UserModel.find({ 'mentorships.0': { $exists: true } })
-            .select('osuId username mentorships')
-            .populate('mentorships.cycle', 'name');
+        const userIds = await MentorshipRecordModel.distinct('user');
+
+        const users = await UserModel.find({ _id: { $in: userIds } })
+            .select('osuId username')
+            .populate({ path: 'mentorships', populate: { path: 'cycle', select: 'name' } });
 
         res.json(users);
-    } catch (error) {
+    } catch {
         res.status(500).json({ error: 'Internal server error' });
     }
 });
 
-/* POST a whole mentorship cycle's participants (bulk, append-with-dedupe).
-   Used by the CMP site (osucmp.com) once at the end of each cycle, so MG's
-   mentorship pages stay accurate without manual re-entry. Modeled on
-   addMentor/addMentee in routes/mentorship.ts. */
-interOpRouter.post('/mentorshipCycle', async (req, res) => {
-    const { number, name, url, startDate, endDate, participants, dryRun } = req.body;
+/*
+    POST new mentorship cycle + participants from osucmp.com
+    for use by -White, who has interOp write permissions.
+    this can only write mentorshipCycle + mentorshipRecords
+*/
+interOpRouter.post('/createMentorshipCycle', canWriteMentorships, async (req, res) => {
+    const { number, name, url, startDate, endDate, participants } = req.body;
 
     if (!number || !Array.isArray(participants)) {
         return res.status(400).json({ error: 'number and participants are required' });
     }
 
+    const errors: string[] = [];
+
+    for (const p of participants) {
+        const needsMentorRef = p.group == 'mentee' || p.group == 'extraMentor';
+
+        if (
+            !p.osuId || !p.mode || !['mentor', 'extraMentor', 'mentee'].includes(p.group) ||
+            (needsMentorRef && !p.mentorOsuId)
+        ) {
+            errors.push(`invalid entry: ${JSON.stringify(p).slice(0, 100)}`);
+        }
+    }
+
+    if (errors.length) {
+        return res.status(400).json({ errors });
+    }
+
+    const osuIds = new Set<number>();
+
+    for (const p of participants) {
+        osuIds.add(p.osuId);
+
+        if (p.mentorOsuId) {
+            osuIds.add(p.mentorOsuId);
+        }
+    }
+
+    const users = await UserModel.find({ osuId: { $in: Array.from(osuIds) } }).select('osuId');
+    const usersByOsuId = new Map(users.map(u => [u.osuId, u]));
+    const missingOsuIds = Array.from(osuIds).filter(id => !usersByOsuId.has(id));
+
+    if (missingOsuIds.length) {
+        return res.status(400).json({
+            error: 'These osuIds are not in the Mappers\' Guild database. Add them manually on the /mentorships page, then resubmit.',
+            missingOsuIds,
+        });
+    }
+
     let cycle = await MentorshipCycleModel.findOne({ number });
 
-    if (!cycle && !dryRun) {
+    if (!cycle) {
         cycle = new MentorshipCycleModel();
         cycle.number = number;
         cycle.name = name || `Cycle ${number}`;
@@ -150,94 +200,41 @@ interOpRouter.post('/mentorshipCycle', async (req, res) => {
         await cycle.save();
     }
 
-    const response = await getClientCredentialsGrant();
-
-    if (isOsuResponseError(response)) {
-        return res.status(500).json({ error: 'osu! auth failed' });
-    }
-
-    const token = response.access_token;
     let created = 0;
     let skipped = 0;
-    const errors: string[] = [];
-
-    const findOrCreateUser = async (osuId: number) => {
-        let user = await UserModel.findOne({ osuId });
-
-        if (!user) {
-            const userInfo = await getUserInfoFromId(token, osuId.toString());
-
-            if (isOsuResponseError(userInfo)) {
-                return null;
-            }
-
-            user = new UserModel();
-            user.osuId = userInfo.id;
-            user.username = userInfo.username;
-            user.group = UserGroup.User;
-
-            if (!dryRun) {
-                await user.save();
-            }
-        }
-
-        return user;
-    };
 
     for (const p of participants) {
-        if (!p.osuId || !p.mode || !['mentor', 'extraMentor', 'mentee'].includes(p.group)) {
-            errors.push(`invalid entry: ${JSON.stringify(p).slice(0, 100)}`);
-            continue;
-        }
+        const user = usersByOsuId.get(p.osuId)!;
 
-        const user = await findOrCreateUser(p.osuId);
-
-        if (!user) {
-            errors.push(`osuId ${p.osuId}: not found on osu!`);
-            continue;
-        }
-
-        const exists = cycle && user.mentorships.some(m =>
-            m.cycle.toString() == cycle.id && m.mode == p.mode && m.group == p.group);
+        const exists = await MentorshipRecordModel.exists({
+            user: user._id,
+            cycle: cycle._id,
+            mode: p.mode,
+            group: p.group,
+        });
 
         if (exists) {
             skipped++;
             continue;
         }
 
-        let mentorRef: any;
+        const newMentorship: any = {
+            user: user._id,
+            cycle: cycle._id,
+            mode: p.mode,
+            group: p.group,
+            phases: p.phases || [1, 2, 3],
+        };
 
-        if (p.group == 'mentee' || p.group == 'extraMentor') {
-            const mentor = await findOrCreateUser(p.mentorOsuId);
-
-            if (!mentor) {
-                errors.push(`osuId ${p.osuId}: mentor ${p.mentorOsuId} not found on osu!`);
-                continue;
-            }
-
-            mentorRef = mentor._id;
+        if (p.mentorOsuId) {
+            newMentorship.mentor = usersByOsuId.get(p.mentorOsuId)!._id;
         }
 
-        if (!dryRun && cycle) {
-            const newMentorship: any = {
-                cycle: cycle._id,
-                mode: p.mode,
-                group: p.group,
-                phases: p.phases || [1, 2, 3],
-            };
-
-            if (mentorRef) {
-                newMentorship.mentor = mentorRef;
-            }
-
-            user.mentorships.push(newMentorship);
-            await user.save();
-        }
-
+        await MentorshipRecordModel.create(newMentorship);
         created++;
     }
 
-    res.json({ created, skipped, errors });
+    res.json({ created, skipped });
 });
 
 export default interOpRouter;

--- a/api/routes/mentorship.ts
+++ b/api/routes/mentorship.ts
@@ -5,6 +5,7 @@ import { LogModel } from '../models/log';
 import { LogCategory } from '../../interfaces/log';
 import { UserGroup } from '../../interfaces/user';
 import { MentorshipCycleModel } from '../models/mentorshipCycle';
+import { MentorshipRecordModel } from '../models/mentorshipRecord';
 import { getUserInfoFromId, isOsuResponseError, getClientCredentialsGrant } from '../helpers/osuApi';
 import { defaultErrorMessage } from '../helpers/helpers';
 
@@ -13,13 +14,24 @@ const mentorshipRouter = express.Router();
 mentorshipRouter.use(isLoggedIn);
 
 const defaultCyclePopulate = [
-    { path: 'participants', select: 'username osuId mentorships' },
+    { path: 'records', populate: { path: 'user', select: 'username osuId' } },
 ];
 
 const userCyclePopulate = [
-    { path: 'mentorships.cycle', select: 'name startDate endDate number url phases' },
-    { path: 'mentorships', populate: { path: 'mentor' } },
-    { path: 'mentees' },
+    {
+        path: 'mentorships',
+        populate: [
+            { path: 'cycle', select: 'name startDate endDate number url' },
+            { path: 'mentor' },
+        ],
+    },
+    {
+        path: 'menteeRecords',
+        populate: {
+            path: 'user',
+            populate: 'mentorships',
+        },
+    },
 ];
 
 /* GET users listing. */
@@ -45,13 +57,10 @@ mentorshipRouter.get('/query', async (req, res) => {
 
 /* GET badge users */
 mentorshipRouter.get('/loadTenureBadges', isMentorshipAdmin, async (req, res) => {
+    const userIds = await MentorshipRecordModel.distinct('user');
+
     const users = await UserModel
-        .find({
-            mentorships: {
-                $exists: true,
-                $ne: [],
-            },
-        })
+        .find({ _id: { $in: userIds } })
         .populate(userCyclePopulate);
 
     const relevantUsers: any[] = [];
@@ -144,6 +153,7 @@ mentorshipRouter.get('/findExtraMentees/:cycleId/:userId/:mode', async (req, res
             .orFail(),
         UserModel
             .findById(userId)
+            .populate('mentorships')
             .orFail(),
     ]);
 
@@ -245,32 +255,21 @@ mentorshipRouter.post('/addCycle', isMentorshipAdmin, async (req, res) => {
             .findById(duplicateCycleId)
             .orFail();
 
-        const users = await UserModel
-            .find({
-                'mentorships.cycle': duplicateCycle._id,
-            })
-            .populate(userCyclePopulate);
+        const duplicateRecords = await MentorshipRecordModel.find({ cycle: duplicateCycle._id });
 
-        for (const user of users) {
-            for (const mentorship of user.mentorships) {
-                if (mentorship.cycle.id === duplicateCycle.id) {
-                    user.mentorships.push({
-                        cycle: cycle._id,
-                        mode: mentorship.mode,
-                        group: mentorship.group,
-                        mentor: mentorship.mentor ? mentorship.mentor._id : null,
-                        phases: mentorship.phases,
-                    });
-                }
-            }
-
-            await user.save();
+        for (const record of duplicateRecords) {
+            await MentorshipRecordModel.create({
+                user: record.user,
+                cycle: cycle._id,
+                mode: record.mode,
+                group: record.group,
+                mentor: record.mentor,
+                phases: record.phases,
+            });
         }
     }
 
-    await cycle.populate({
-        path: 'participants',
-    });
+    await cycle.populate(defaultCyclePopulate);
 
     res.json(cycle);
 });
@@ -335,13 +334,14 @@ mentorshipRouter.post('/addMentor', isMentorshipAdmin, async (req, res) => {
         }
     }
 
-    const exists = user.mentorships.some(m => m.cycle.toString() == cycle.id && m.mode == mode);
+    const exists = await MentorshipRecordModel.exists({ user: user._id, cycle: cycle._id, mode });
 
     if (exists) {
         return res.json({ error: 'User already mentor for this cycle and mode' });
     }
 
     const newMentorship: any = {
+        user: user._id,
         cycle: cycle._id,
         mode,
         group: mainMentorId ? 'extraMentor' : 'mentor',
@@ -352,13 +352,9 @@ mentorshipRouter.post('/addMentor', isMentorshipAdmin, async (req, res) => {
         newMentorship.mentor = mainMentorId;
     }
 
-    user.mentorships.push(newMentorship);
+    await MentorshipRecordModel.create(newMentorship);
 
-    await user.save();
-
-    await cycle.populate({
-        path: 'participants',
-    });
+    await cycle.populate(defaultCyclePopulate);
 
     res.json(cycle);
 });
@@ -419,7 +415,7 @@ mentorshipRouter.post('/addMentee', isMentorshipAdmin, async (req, res) => {
         }
     }
 
-    const mentorshipsThisCycle = user.mentorships.filter(m => m.cycle.toString() == cycle.id && m.mode == mode);
+    const mentorshipsThisCycle = await MentorshipRecordModel.find({ user: user._id, cycle: cycle._id, mode });
     const phases: number[] = [];
 
     if (mentorshipsThisCycle && mentorshipsThisCycle.length) {
@@ -444,7 +440,8 @@ mentorshipRouter.post('/addMentee', isMentorshipAdmin, async (req, res) => {
         return res.json({ error: 'User already mentee for all phases in this cycle and mode' });
     }
 
-    user.mentorships.push({
+    await MentorshipRecordModel.create({
+        user: user._id,
         cycle: cycle._id,
         mode,
         group: 'mentee',
@@ -452,11 +449,7 @@ mentorshipRouter.post('/addMentee', isMentorshipAdmin, async (req, res) => {
         phases: validPhases,
     });
 
-    await user.save();
-
-    await cycle.populate({
-        path: 'participants',
-    });
+    await cycle.populate(defaultCyclePopulate);
 
     res.json(cycle);
 });
@@ -465,7 +458,7 @@ mentorshipRouter.post('/addMentee', isMentorshipAdmin, async (req, res) => {
 mentorshipRouter.post('/removeParticipant', isMentorshipAdmin, async (req, res) => {
     const { cycleId, userId, mode } = req.body;
 
-    const [cycle, user] = await Promise.all([
+    const [cycle] = await Promise.all([
         MentorshipCycleModel
             .findById(cycleId)
             .populate(defaultCyclePopulate)
@@ -475,17 +468,13 @@ mentorshipRouter.post('/removeParticipant', isMentorshipAdmin, async (req, res) 
             .orFail(),
     ]);
 
-    const i = user.mentorships.findIndex(m => m.cycle.toString() == cycle.id && m.mode == mode);
+    const mentorship = await MentorshipRecordModel.findOne({ user: userId, cycle: cycleId, mode });
 
-    if (i !== -1) {
-        user.mentorships.splice(i, 1);
+    if (mentorship) {
+        await mentorship.deleteOne();
     }
 
-    await user.save();
-
-    await cycle.populate({
-        path: 'participants',
-    });
+    await cycle.populate(defaultCyclePopulate);
 
     res.json(cycle);
 });
@@ -511,9 +500,7 @@ mentorshipRouter.post('/updateCycleName', isMentorshipAdmin, async (req, res) =>
     cycle.name = name;
     await cycle.save();
 
-    await cycle.populate({
-        path: 'participants',
-    });
+    await cycle.populate(defaultCyclePopulate);
 
     res.json(cycle);
 });
@@ -539,9 +526,7 @@ mentorshipRouter.post('/updateCycleNumber', isMentorshipAdmin, async (req, res) 
     cycle.number = finalNumber;
     await cycle.save();
 
-    await cycle.populate({
-        path: 'participants',
-    });
+    await cycle.populate(defaultCyclePopulate);
 
     res.json(cycle);
 });
@@ -559,9 +544,7 @@ mentorshipRouter.post('/updateCycleUrl', isMentorshipAdmin, async (req, res) => 
     cycle.url = finalUrl;
     await cycle.save();
 
-    await cycle.populate({
-        path: 'participants',
-    });
+    await cycle.populate(defaultCyclePopulate);
 
     res.json(cycle);
 });
@@ -585,9 +568,7 @@ mentorshipRouter.post('/updateCycleStartDate', isMentorshipAdmin, async (req, re
     cycle.startDate = finalStartDate;
     await cycle.save();
 
-    await cycle.populate({
-        path: 'participants',
-    });
+    await cycle.populate(defaultCyclePopulate);
 
     res.json(cycle);
 });
@@ -611,9 +592,7 @@ mentorshipRouter.post('/updateCycleEndDate', isMentorshipAdmin, async (req, res)
     cycle.endDate = finalEndDate;
     await cycle.save();
 
-    await cycle.populate({
-        path: 'participants',
-    });
+    await cycle.populate(defaultCyclePopulate);
 
     res.json(cycle);
 });
@@ -630,9 +609,7 @@ mentorshipRouter.post('/toggleCycleIsPublic', isMentorshipAdmin, async (req, res
     cycle.isPublic = !cycle.isPublic;
     await cycle.save();
 
-    await cycle.populate({
-        path: 'participants',
-    });
+    await cycle.populate(defaultCyclePopulate);
 
     res.json(cycle);
 });
@@ -679,37 +656,34 @@ mentorshipRouter.post('/togglePhase', isMentorshipAdmin, async (req, res) => {
             .orFail(),
         UserModel
             .findById(userId)
-            .populate(userCyclePopulate)
             .orFail(),
     ]);
 
-    let mentorshipIndex;
+    const query: any = { user: user._id, cycle: cycle._id, mode };
 
     if (mentorId) {
-        mentorshipIndex = user.mentorships.findIndex(m => m.cycle.id == cycle.id && m.mode == mode && m.mentor.id == mentorId);
-    } else {
-        mentorshipIndex = user.mentorships.findIndex(m => m.cycle.id == cycle.id && m.mode == mode);
+        query.mentor = mentorId;
     }
 
-    const mentorship = user.mentorships[mentorshipIndex];
+    const mentorship = await MentorshipRecordModel.findOne(query);
 
-    if (mentorshipIndex == -1) {
+    if (!mentorship) {
         return res.json({ error: `Couldn't find mentorship` });
     }
 
     // toggle the phase for relevant user's mentorship entry. save after following checks
-    const phaseIndex = user.mentorships[mentorshipIndex].phases.indexOf(phaseNum);
+    const phaseIndex = mentorship.phases.indexOf(phaseNum);
 
     if (phaseIndex !== -1) {
-        user.mentorships[mentorshipIndex].phases.splice(phaseIndex, 1);
+        mentorship.phases.splice(phaseIndex, 1);
     } else {
         // ensure the phase isn't active for another mentorship in the same cycle
-        const mentorshipsThisCycle = user.mentorships.filter(m => m.cycle.id == cycle.id && m.mode == mode);
+        const mentorshipsThisCycle = await MentorshipRecordModel.find({ user: user._id, cycle: cycle._id, mode });
         const phases: number[] = [];
 
         if (mentorshipsThisCycle && mentorshipsThisCycle.length) {
-            for (const mentorship of mentorshipsThisCycle) {
-                for (const phase of mentorship.phases) {
+            for (const m of mentorshipsThisCycle) {
+                for (const phase of m.phases) {
                     phases.push(phase);
                 }
             }
@@ -718,39 +692,28 @@ mentorshipRouter.post('/togglePhase', isMentorshipAdmin, async (req, res) => {
         if (phases.includes(phaseNum) && mentorId) {
             return res.json({ error: 'Mentee is already mentored in this phase of this cycle in this mode' });
         } else {
-            user.mentorships[mentorshipIndex].phases.push(phaseNum);
+            mentorship.phases.push(phaseNum);
         }
     }
 
     // disallow removing phases if mentee is logged in that phase
     if (mentorship.group == 'mentor') {
-        const cycleMentees = await UserModel
-            .find({
-                'mentorships.cycle': cycle.id,
-                'mentorships.mentor': user.id,
-            } as any)
-            .populate(userCyclePopulate);
+        const cycleMentees = await MentorshipRecordModel.find({ cycle: cycle._id, mode, mentor: user._id });
 
-        for (const mentee of cycleMentees) {
-            const menteeMentorshipIndex = mentee.mentorships.findIndex(m => m.cycle.id == cycle.id && m.mode == mode && m.mentor.id == user.id);
+        for (const menteeRecord of cycleMentees) {
+            const menteePhaseIndex = menteeRecord.phases.indexOf(phaseNum);
 
-            if (menteeMentorshipIndex !== -1) {
-                const menteePhaseIndex = mentee.mentorships[menteeMentorshipIndex].phases.indexOf(phaseNum);
-
-                // return if mentee is in phase that you're trying to remove from mentor
-                if (phaseIndex !== -1 && menteePhaseIndex !== -1) {
-                    return res.json({ error: `Can't remove mentor from phase while mentee(s) are in phase` });
-                }
+            // return if mentee is in phase that you're trying to remove from mentor
+            if (phaseIndex !== -1 && menteePhaseIndex !== -1) {
+                return res.json({ error: `Can't remove mentor from phase while mentee(s) are in phase` });
             }
         }
     } else if (mentorship.group == 'mentee') {
-        const mentor = await UserModel
-            .findById(mentorship.mentor._id)
-            .populate(userCyclePopulate)
+        const mentorMentorship = await MentorshipRecordModel
+            .findOne({ user: mentorship.mentor, cycle: cycle._id, mode })
             .orFail();
 
-        const mentorMentorshipIndex = mentor.mentorships.findIndex(m => m.cycle.id == cycle.id && m.mode == mode);
-        const mentorPhaseIndex = mentor.mentorships[mentorMentorshipIndex].phases.indexOf(phaseNum);
+        const mentorPhaseIndex = mentorMentorship.phases.indexOf(phaseNum);
 
         // return if mentor isn't mentoring that phase
         if (mentorPhaseIndex == -1) {
@@ -758,11 +721,9 @@ mentorshipRouter.post('/togglePhase', isMentorshipAdmin, async (req, res) => {
         }
     }
 
-    await user.save();
+    await mentorship.save();
 
-    await cycle.populate({
-        path: 'participants',
-    });
+    await cycle.populate(defaultCyclePopulate);
 
     res.json(cycle);
 });

--- a/api/routes/mentorship.ts
+++ b/api/routes/mentorship.ts
@@ -728,6 +728,27 @@ mentorshipRouter.post('/togglePhase', isMentorshipAdmin, async (req, res) => {
     res.json(cycle);
 });
 
+/* POST delete cycle + all mentorship records tied to it */
+mentorshipRouter.post('/deleteCycle', isMentorshipAdmin, async (req, res) => {
+    const { cycleId } = req.body;
+
+    if (res.locals.userRequest.osuId !== 16276548) {
+        return res.json({ error: 'Only -White can delete cycles' });
+    }
+
+    const cycle = await MentorshipCycleModel
+        .findById(cycleId)
+        .orFail();
+
+    const { deletedCount } = await MentorshipRecordModel.deleteMany({ cycle: cycle._id });
+
+    await cycle.deleteOne();
+
+    res.json({ success: true });
+
+    LogModel.generate(req.session?.mongoId, `deleted mentorship cycle "${cycle.name}" (#${cycle.number}) and ${deletedCount} mentorship record(s)`, LogCategory.Mentorship);
+});
+
 /* POST edit badge value */
 mentorshipRouter.post('/editBadgeValue', isMentorshipAdmin, async (req, res) => {
     const { userId, value } = req.body;

--- a/config.example.json
+++ b/config.example.json
@@ -38,7 +38,8 @@
     "interOpAccess": {
         "USERNAME": {
             "mongoId": "",
-            "secret": ""
+            "secret": "",
+            "canWriteMentorships": false
         }
     },
     "shopify": {

--- a/interfaces/mentorshipCycle.ts
+++ b/interfaces/mentorshipCycle.ts
@@ -1,4 +1,6 @@
+import { Document } from 'mongoose';
 import { User } from './user';
+import { MentorshipRecord } from './mentorshipRecord';
 
 export interface MentorshipCycle extends Document {
     _id: any;
@@ -11,5 +13,7 @@ export interface MentorshipCycle extends Document {
     isPublic: boolean;
 
     /** virtual field to populate */
-    participants: User[];
+    records: MentorshipRecord[];
+    /** virtual field computed from "records" */
+    participants: (Pick<User, '_id' | 'id' | 'username' | 'osuId'> & { mentorships: MentorshipRecord[] })[];
 }

--- a/interfaces/mentorshipRecord.ts
+++ b/interfaces/mentorshipRecord.ts
@@ -1,0 +1,24 @@
+import { Document } from 'mongoose';
+import { User } from './user';
+import { MentorshipCycle } from './mentorshipCycle';
+
+export type MentorshipMode =
+    'osu' | 'taiko' | 'catch' | 'mania' |
+    'osuModding' | 'taikoModding' | 'catchModding' | 'maniaModding' |
+    'osuGraduation' | 'taikoGraduation' | 'catchGraduation' | 'maniaGraduation' |
+    'storyboard';
+
+export type MentorshipGroup = 'mentor' | 'mentee' | 'extraMentor';
+
+export interface MentorshipRecord extends Document {
+    _id: any;
+    id: string;
+    user: User;
+    cycle: MentorshipCycle;
+    mode: MentorshipMode;
+    group: MentorshipGroup;
+    mentor: User;
+    phases: number[];
+    createdAt: Date;
+    updatedAt: Date;
+}

--- a/interfaces/user.ts
+++ b/interfaces/user.ts
@@ -1,7 +1,7 @@
 import { BeatmapMode } from './beatmap/beatmap';
 import { Quest } from './quest';
 import { Mission } from './mission';
-import { MentorshipCycle } from './mentorshipCycle';
+import { MentorshipRecord } from './mentorshipRecord';
 import { FeaturedArtist } from './featuredArtist';
 import { Document } from 'mongoose';
 import { OsuCover } from '../api/helpers/osuApi';
@@ -33,13 +33,8 @@ export interface User extends Document {
     discordId: string; // js doesnt support 18 digit numbers...
     isMentorshipAdmin: boolean;
     isTeamContestAdmin: boolean;
-    mentorships: {
-        cycle: MentorshipCycle;
-        mode: string;
-        group: string;
-        mentor: User;
-        phases: number[];
-    }[];
+    /** virtual field to populate */
+    mentorships: MentorshipRecord[];
     rank: number;
     easyPoints: number;
     normalPoints: number;
@@ -68,7 +63,10 @@ export interface User extends Document {
     pointsInfo: Record<string, any>;
     mainMode: Omit<BeatmapMode, BeatmapMode.Hybrid>;
     createdAt: Date;
+    /** virtual field to populate (via menteeRecords) */
     mentees: User[];
+    /** virtual field to populate ("user" sub-populate required to compute "mentees") */
+    menteeRecords: MentorshipRecord[];
     rankedBeatmapsCount: number;
     globalRank: number;
     pp: number;

--- a/src/components/mentorship/CycleList.vue
+++ b/src/components/mentorship/CycleList.vue
@@ -168,7 +168,7 @@ export default defineComponent({
             if (this.extraMentees && this.extraMentees.length) {
                 for (const mentee of this.extraMentees) {
                     for (const mentorship of mentee.mentorships) {
-                        if (mentorship.cycle.toString() == argMentorship.cycle.id && mentorship.group == 'mentee' && mentorship.mode == this.mode && mentorship.mentor.toString() == argMentorship.mentor.id) {
+                        if (mentorship.cycle.toString() == argMentorship.cycle.id && mentorship.group == 'mentee' && mentorship.mode == this.mode && argMentorship.mentor && mentorship.mentor.toString() == argMentorship.mentor.id) {
                             mentees.push(mentee);
                         }
                     }

--- a/src/components/mentorship/ParticipantList.vue
+++ b/src/components/mentorship/ParticipantList.vue
@@ -16,11 +16,20 @@
                         class="text-secondary"
                     >*</span>
                     <a
+                        v-if="editingMentorId != user.id"
                         href="#"
                         class="text-success ms-1 small"
                         @click.prevent="editingMentorId = user.id"
                     >
                         <i class="fas fa-plus" />
+                    </a>
+                    <a
+                        v-else
+                        href="#"
+                        class="text-secondary ms-1 small"
+                        @click.prevent="cancelEditingMentor()"
+                    >
+                        <i class="fas fa-times" />
                     </a>
                     <span v-if="!findMentees(user.id).length">
                         <a
@@ -310,6 +319,11 @@ export default defineComponent({
         }
     },
     methods: {
+        cancelEditingMentor(): void {
+            this.editingMentorId = '';
+            this.extraMentorInput = null;
+            this.menteeInput = null;
+        },
         findMentees(id): User[] {
             const mentees = this.modeMentees.filter(p => {
                 for (const mentorship of p.mentorships) {
@@ -366,6 +380,7 @@ export default defineComponent({
                 this.$store.commit('mentorship/updateCycle', cycle);
                 this.mentorInput = null;
                 this.extraMentorInput = null;
+                this.editingMentorId = '';
             }
         },
         async addMentee(e, mentorId): Promise<void> {

--- a/src/components/mentorship/Participants.vue
+++ b/src/components/mentorship/Participants.vue
@@ -14,7 +14,7 @@
                             Select a cycle
                         </option>
                         <option v-for="cycle in allCycles" :key="cycle.id" :value="cycle.id">
-                            {{ cycle.number }} - {{ cycle.name }}
+                            {{ cycle.number }} - {{ cycle.name }}{{ !cycle.isPublic ? ' (NOT PUBLIC)' : '' }}
                         </option>
                     </select>
                 </div>

--- a/src/components/mentorship/Participants.vue
+++ b/src/components/mentorship/Participants.vue
@@ -163,6 +163,47 @@
                             </button>
                         </div>
                     </div>
+                    <!-- delete cycle -->
+                    <div class="row">
+                        <div class="col-sm-2">
+                            Delete cycle:
+                        </div>
+                        <div class="col-sm-4 mb-2">
+                            <button
+                                v-if="!confirmDeleteCycle"
+                                class="btn btn-outline-danger btn-sm"
+                                href="#"
+                                @click.prevent="confirmDeleteCycle = true"
+                            >
+                                delete this cycle
+                            </button>
+                            <div v-else>
+                                <div class="text-danger small mb-1">
+                                    This permanently deletes "{{ selectedCycle.name }}" and every mentorship record tied to it. Type the cycle name below to confirm.
+                                </div>
+                                <div class="input-group input-group-sm mb-1">
+                                    <input
+                                        v-model="deleteCycleConfirmInput"
+                                        class="form-control form-control-sm"
+                                        autocomplete="off"
+                                        :placeholder="selectedCycle.name"
+                                    />
+                                    <div class="input-group-append">
+                                        <button
+                                            class="btn btn-danger"
+                                            :disabled="deleteCycleConfirmInput !== selectedCycle.name"
+                                            @click.prevent="deleteCycle($event)"
+                                        >
+                                            permanently delete
+                                        </button>
+                                    </div>
+                                </div>
+                                <a href="#" class="small" @click.prevent="confirmDeleteCycle = false; deleteCycleConfirmInput = ''">
+                                    cancel
+                                </a>
+                            </div>
+                        </div>
+                    </div>
                     <a href="#" @click.prevent="showCycleInputs = !showCycleInputs">
                         stop editing (close without saving)
                     </a>
@@ -271,6 +312,8 @@ export default defineComponent({
             cycleUrlInput: null,
             cycleStartDateInput: new Date(),
             cycleEndDateInput: new Date(),
+            confirmDeleteCycle: false,
+            deleteCycleConfirmInput: '',
         };
     },
     computed: {
@@ -288,6 +331,9 @@ export default defineComponent({
     watch: {
         cycleId(): void {
             this.$store.commit('mentorship/setSelectedCycleId', this.cycleId);
+
+            if (!this.selectedCycle) return;
+
             this.cycleNameInput = this.selectedCycle.name;
             this.cycleNumberInput = this.selectedCycle.number;
             this.cycleUrlInput = this.selectedCycle.url;
@@ -357,6 +403,21 @@ export default defineComponent({
                     type: 'info',
                 });
                 this.$store.commit('mentorship/updateCycle', cycle);
+            }
+        },
+        async deleteCycle(e): Promise<void> {
+            const result: any = await this.$http.executePost(`/mentorship/deleteCycle`, { cycleId: this.selectedCycle.id }, e);
+
+            if (!this.$http.isError(result)) {
+                this.$store.dispatch('updateToastMessages', {
+                    message: `Deleted cycle "${this.selectedCycle.name}"`,
+                    type: 'info',
+                });
+                this.$store.commit('mentorship/removeCycle', this.selectedCycle.id);
+                this.cycleId = this.allCycles.length ? this.allCycles[0].id : '';
+                this.confirmDeleteCycle = false;
+                this.deleteCycleConfirmInput = '';
+                this.showCycleInputs = false;
             }
         },
         async toggleCycleIsPublic(e): Promise<void> {

--- a/src/store/mentorship.ts
+++ b/src/store/mentorship.ts
@@ -46,6 +46,10 @@ const store: Module<UsersState, MainState> = {
             const i = state.cycles.findIndex(c => c.id === cycle.id);
             if (i !== -1) state.cycles[i] = cycle;
         },
+        removeCycle (state, cycleId: string): void {
+            const i = state.cycles.findIndex(c => c.id === cycleId);
+            if (i !== -1) state.cycles.splice(i, 1);
+        },
         setSelectedUser (state, user: User): void {
             state.selectedUser = user;
         },


### PR DESCRIPTION
Hi! This is from the osu! Community Mentorship Program (CMP) — we run the mentorship cycles that live on your mentorship pages, and we now track everything (applications, picks, pairings, partial participation) on our own site.

We already use `GET /interop/allMentorships` with our interop credential (thanks!). This PR adds the write counterpart so we can push a finished cycle's participants **once, manually, at the end of each cycle** instead of re-entering everyone through the admin UI:

### `POST /api/interop/mentorshipCycle`

```json
{
  "number": 33, "name": "Cycle 33", "url": "https://osu.ppy.sh/community/forums/topics/2190873",
  "startDate": "2026-04-26", "endDate": "2026-07-26", "dryRun": false,
  "participants": [
    { "osuId": 123, "mode": "osu", "group": "mentor" },
    { "osuId": 456, "mode": "osu", "group": "extraMentor", "mentorOsuId": 123 },
    { "osuId": 789, "mode": "osu", "group": "mentee", "mentorOsuId": 123, "phases": [2, 3] }
  ]
}
```

- **Append-with-dedupe**: entries that already exist for that cycle+mode+group are skipped, so re-sending is harmless. Existing cycles are matched by `number` and never modified.
- **Users are auto-created from the osu! API** when unknown — same code path as your `addMentor`.
- **`dryRun: true`** validates and reports without writing.
- Responds `{ created, skipped, errors }`.
- `phases` come from our side computed from each pairing's real start/end (thirds of the cycle), so partial participation carries over correctly.

The implementation deliberately mirrors `addMentor`/`addMentee` in `routes/mentorship.ts` (same model usage, same user auto-creation). I couldn't run your build locally, so please double-check typings — happy to adjust anything about the contract or code. Our side is already built and behind a manual organizer button, so nothing will call this more than once per cycle.

— -White (CMP)